### PR TITLE
Updates svg2png

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "map-stream": "~0.1.0",
-    "svg2png": "~1.0.1",
+    "svg2png": "~1.1.0",
     "gulp-util": "~2.2.14"
   }
 }


### PR DESCRIPTION
Please update svg2png to v1.1.0. It solves a common issue with scaling SVGs exported from Illustrator. https://github.com/domenic/svg2png/commit/d4a15a7a6f960acce53402599e8e2774e729c217
