### PR TITLE
Fix that makes the plug-in actually work.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,6 @@ import path = require('path');
 
 import gutil = require('gulp-util');
 
-const pn = require('pn/fs');
 const map_limit = require('map-stream-limit');
 const map = require('map-stream');
 const svg2png = require('svg2png');
@@ -67,15 +66,14 @@ class Command {
 	}
 
 	execute(source: any, cb: Function) {
+		if (!source.isBuffer()) {
+			return this.error('Streams are not supported by the underlying svg2png library.');
+		}
 		if (!SVG.is(source.contents)) {
 			return this.error('Source is not a SVG file.');
 		}
 
-		pn
-			.readFile(source.path)
-			.then((buffer: Buffer) =>
-				svg2png(buffer, this.options)
-			)
+		svg2png(source.contents, this.options)
 			.then((contents: Buffer) =>
 				cb(null, new gutil.File({
 					base: source.base,
@@ -98,4 +96,3 @@ export = (options: Object = {}, verbose: boolean = true, concurrency: number = n
 		return map(cmd.execute.bind(cmd));
 	}
 };
-

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "gulp-util": "^3.0.7",
     "map-stream": "0.0.6",
     "map-stream-limit": "^1.1.0",
-    "pn": "^1.0.0",
     "svg2png": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
At the moment the plug-in literally does not work when called by Gulp.

This patch fixes that, by removing the use of pn to open the file,
which has already been read into memory by gulp anyway.

svg2png already uses promises so there is no effect on synchronicity.

Added an extra error message to remind users that only Buffers are
supported, not streams. I'm not sure if this will affect anybody.

An added bonus is that any changes made by gulp to the file will
now be reflected by gulp-svg2png.

Addresses issues #23.