### PR TITLE
Fix engines, update svg2png to 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ typings
 *.js
 npm-debug.log
 .DS_Store
+.idea

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"gulp-util": "^3.0.7",
 		"map-stream": "0.0.6",
 		"map-stream-limit": "^1.1.0",
-		"svg2png": "^4.1.0"
+		"svg2png": "^4.1.1"
 	},
 	"devDependencies": {
 		"@types/chai": "^3.4.34",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"gulp-util": "^3.0.7",
 		"map-stream": "0.0.6",
 		"map-stream-limit": "^1.1.0",
-		"svg2png": "^4.1.1"
+		"svg2png": "^3.0.0"
 	},
 	"devDependencies": {
 		"@types/chai": "^3.4.34",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"test": "npm run build && npm run mocha"
 	},
 	"engines": {
-		"node": "^6.0.0 || ^7.0.0"
+		"node": ">=6.0.0"
 	},
 	"repository": {
 		"type": "git",
@@ -34,7 +34,7 @@
 		"gulp-util": "^3.0.7",
 		"map-stream": "0.0.6",
 		"map-stream-limit": "^1.1.0",
-		"svg2png": "^3.0.0"
+		"svg2png": "^4.0.0"
 	},
 	"devDependencies": {
 		"@types/chai": "^3.4.34",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"gulp-util": "^3.0.7",
 		"map-stream": "0.0.6",
 		"map-stream-limit": "^1.1.0",
-		"svg2png": "^4.0.0"
+		"svg2png": "^4.1.0"
 	},
 	"devDependencies": {
 		"@types/chai": "^3.4.34",


### PR DESCRIPTION
Hi! Had trouble with engine compatibility on node v7.1.1, here is a pull to fix that. Also updating svg2png to 4th version.