### PR TITLE
Add support for Node v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"test": "npm run build && npm run mocha"
 	},
 	"engines": {
-		"node": "^6.0.0 || ^7.0.0"
+		"node": "^6.0.0 || ^7.0.0 || ^8.0.0"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
I followed the current format, otherwise I would have used `"node" : ">=6.0.0 <9.0.0"`